### PR TITLE
[dependencies] Use latest semiotic version (Fixes #19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^16.5.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.5",
-    "semiotic": "1.20.2"
+    "semiotic": "1.20.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7671,10 +7671,10 @@ semiotic-mark@0.3.1:
     prop-types "^15.6.0"
     roughjs-es5 "0.1.0"
 
-semiotic@1.20.2:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-1.20.2.tgz#3745ae51fb257270194694aa821819c1e2841e39"
-  integrity sha512-uTZHpOcN5slAIffamgB4egAjbpEeibJ0eXhHYHg1VqB011Sa4JjH51gG51OmNAg46Y96m0gzCodyIuAnjFYg/Q==
+semiotic@1.20.3:
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-1.20.3.tgz#9126e567128768cfcd40d10497063fabaafe3b05"
+  integrity sha512-9Pw3NJtNSBNKA3TL7IXWgvBupqw64h1gG7VX1+6HYnmSyAfZe2cH+ixylVsg0l3ajKfFeOdG5xy119tv9ba33g==
   dependencies:
     "@mapbox/polylabel" "1"
     d3-array "^1.2.0"


### PR DESCRIPTION
Motivation: prevents the waterfall example from crashing the page, including a commit which allows custom layouts to return either positioning objects *or* SVG elements for `OrdinalFrame`: 

https://github.com/nteract/semiotic/commit/56577bee7d7a3ad5172213e829cc34e9667698cd#diff-bd358c5975a9c00b32a3addf8402032c

